### PR TITLE
fix: Stage alias 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts as builder
+FROM node:lts
 WORKDIR /app/
 COPY . .
 RUN ["npm", "i", "-g", "npm"]
@@ -11,7 +11,7 @@ WORKDIR /app/
 EXPOSE 80
 ENV NODE_ENV production
 ENV PORT 80
-COPY --from=builder /app/ .
+COPY --from=0 /app/ .
 RUN ["npm", "i", "-g", "npm", "pm2"]
 RUN ["npm", "i", "--production", "--ignore-scripts"]
 ENTRYPOINT ["pm2", "start", "applications/network/dist/index.js", "--no-daemon"]


### PR DESCRIPTION
## 관련 이슈

## 현재 상황
AWS EB에서 `FROM ~ as ~`를 인식하고 있지 않음.

## 개선 방법
alias를 제거하고 스테이지를 가리킬 때 번호를 사용하도록 변경함.

## 예상 되는 부수 효과

## TODO
- [ ] 테스트 코드 작성
- [x] 비즈니스 로직 작성
- [x] 로컬 환경에서 테스트

## Reference
